### PR TITLE
Valorium v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+Valorium v0.17.0 - 16/06/2024
+---------------
+
+- **Adicionado**:
+  - Configurações para Item Highlighter v1.1.9
+
+- **Modificado**:
+  - Balm v7.2.2 para v7.3.4
+  - Entity Culling v1.6.2 para v1.6.6
+  - [ETF] Entity Texture Features v6.0.1 para v6.1.1
+  - Fabric API v0.92.1 para v0.92.2
+  - Indium v1.0.30 para v1.0.32
+  - Iris Shaders v1.7.0 para v1.7.1
+  - ModernFix v5.17.0 para v5.18.1
+  - Sodium v0.5.8 para v0.5.10
+  - YetAnotherConfigLib v3.4.2 para v3.5.0
+
 Valorium v0.16.2 - 26/05/2024
 ---------------
 

--- a/configureddefaults/config/entity_texture_features.json
+++ b/configureddefaults/config/entity_texture_features.json
@@ -11,6 +11,7 @@
   "enableArmorAndTrims": true,
   "skinFeaturesEnabled": true,
   "skinTransparencyMode": "ETF_SKINS_ONLY",
+  "skinTransparencyInExtraPixels": true,
   "skinFeaturesEnableTransparency": true,
   "skinFeaturesEnableFullTransparency": false,
   "tryETFTransparencyForAllSkins": false,

--- a/configureddefaults/config/highlighter-common.toml
+++ b/configureddefaults/config/highlighter-common.toml
@@ -1,0 +1,19 @@
+
+#Client Configuration
+[client]
+
+	[client.options]
+		# If new item markers should be cleared when the inventory is closed.
+		clear_on_close = true
+		# If new item markers should be cleared when the item tooltip is displayed.
+		clear_on_hover = true
+		# If new item markers should be cleared when the item is selected on the hotbar.
+		clear_on_select = true
+		# If icons should match the color of items names (as shown in tooltips).  Otherwise icons will all be gold.
+		item_name_color = false
+		# If new item markers should show on the hotbar.
+		show_on_hotbar = true
+		# The position of new item markers.
+		#Allowed Values: UpperLeft, UpperRight, LowerLeft, LowerRight
+		icon_position = "UpperLeft"
+

--- a/index.toml
+++ b/index.toml
@@ -62,11 +62,15 @@ hash = "0103610444b018e2af9c622a4750df5dcc8fc020ff5b80b497345c689325023a"
 
 [[files]]
 file = "configureddefaults/config/entity_texture_features.json"
-hash = "01c5e145f4d1a199e07e6d4dc786d34ee2ede8eb03b64b3185f4998d398efcfe"
+hash = "52ce53c9db6a1bb90b5f83f773f02a8cb8f336182c1ecf58302103149299e850"
 
 [[files]]
 file = "configureddefaults/config/entityculling.json"
 hash = "a24505b1270f7e0dad1d2863ca82d459790cebeaf64d0c62c160bf0033faeacd"
+
+[[files]]
+file = "configureddefaults/config/highlighter-common.toml"
+hash = "22b7f87be30b7e3ce6fa3fe1cb588e8b3eae0bfc9ddc390ad346a1d1bbfebb4b"
 
 [[files]]
 file = "configureddefaults/config/iris.properties"
@@ -99,7 +103,7 @@ metafile = true
 
 [[files]]
 file = "mods/balm.pw.toml"
-hash = "ab6a6dc2a3fa157464f0294d8b5d3e6b8b882c9b520c7f7e0ca8329094ed1dfa"
+hash = "f4fce67c57b4c42e12e705c25ec3feedb85cef927c2578983e59a59582c81ace"
 metafile = true
 
 [[files]]
@@ -189,12 +193,12 @@ metafile = true
 
 [[files]]
 file = "mods/entityculling.pw.toml"
-hash = "33f865a014f3acf2c1f2c452bfe7ba1a864acad178322a6eab3759c7e63c9654"
+hash = "9f499eff7ddb9eeab719f19808cbcf41f2b77d06ebf946f157cf7b5f52f64e70"
 metafile = true
 
 [[files]]
 file = "mods/entitytexturefeatures.pw.toml"
-hash = "3251a3699322607d89dccdd4efef359e0aaa2f9a21e011265c36e165423d83c9"
+hash = "8a9c5e182dc4d4792103277e2003062de2718a4167edb9082d69efcbfc19cb87"
 metafile = true
 
 [[files]]
@@ -204,7 +208,7 @@ metafile = true
 
 [[files]]
 file = "mods/fabric-api.pw.toml"
-hash = "f957e7280d9bae7569829edcaff25b0ba05ddb029d24f4ea53bdfb0a79615fad"
+hash = "86698b1faa9bf449eab492509239372302311092104be467108d7e05127e91f1"
 metafile = true
 
 [[files]]
@@ -244,12 +248,12 @@ metafile = true
 
 [[files]]
 file = "mods/indium.pw.toml"
-hash = "e416b18eebf514dea2014cf5c7fd3ee8493934a0b4e937509f15172ad271fde2"
+hash = "523659698dcfb97f79c9971a9c3ce41ba5e654d55b0464d73da01a63cd9a1824"
 metafile = true
 
 [[files]]
 file = "mods/iris.pw.toml"
-hash = "bea7422cbe82074a7e6306cdcd0ab8941cce0e86e439fcbffd3d9930de3e32a3"
+hash = "268c5ed7677153bbf1bc4d37e6d5825388fa5d444c67f4b399fd4ce708b773b5"
 metafile = true
 
 [[files]]
@@ -289,7 +293,7 @@ metafile = true
 
 [[files]]
 file = "mods/modernfix.pw.toml"
-hash = "8bd4f3e61a962c0b730a9a9b5ce875b571ae7e39d350ad52b17f9fab467a3784"
+hash = "a4ed08cb6d5da7893d0f90c077e514a3d1e1c51168bb21182e972277f12b1dab"
 metafile = true
 
 [[files]]
@@ -324,7 +328,7 @@ metafile = true
 
 [[files]]
 file = "mods/sodium.pw.toml"
-hash = "cd49906a91e2ff1c11acba79192d609c232f2f73d82cc6a646e7338c8e76aa8a"
+hash = "c3774af2e5f18da0c4cb00f95421a08bf9f0dda90a4169ce87b021d2f8d0dbce"
 metafile = true
 
 [[files]]
@@ -339,5 +343,5 @@ metafile = true
 
 [[files]]
 file = "mods/yacl.pw.toml"
-hash = "34108efa4206b09f00d088be089236914a6fb04852aae5b6ce6293412ed6a6f7"
+hash = "5fa3a100f874ad3d03b674e867105fc7cc7dcf98b5c1c50d7841a25a0dda4607"
 metafile = true

--- a/mods/balm.pw.toml
+++ b/mods/balm.pw.toml
@@ -1,13 +1,13 @@
 name = "Balm"
-filename = "balm-fabric-1.20.1-7.2.2.jar"
+filename = "balm-fabric-1.20.1-7.3.4.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/MBAkmtvl/versions/v1tAteat/balm-fabric-1.20.1-7.2.2.jar"
+url = "https://cdn.modrinth.com/data/MBAkmtvl/versions/de1sItvo/balm-fabric-1.20.1-7.3.4.jar"
 hash-format = "sha1"
-hash = "ce3a8468cddcd1bb40e60958e809e003a85a20c2"
+hash = "bb0ad4e00d5876b3c44d331ecbef96cb0c5233b2"
 
 [update]
 [update.modrinth]
 mod-id = "MBAkmtvl"
-version = "v1tAteat"
+version = "de1sItvo"

--- a/mods/entityculling.pw.toml
+++ b/mods/entityculling.pw.toml
@@ -1,13 +1,13 @@
 name = "Entity Culling"
-filename = "entityculling-fabric-1.6.2-mc1.20.1.jar"
+filename = "entityculling-fabric-1.6.6-mc1.20.1.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/NNAgCjsB/versions/BDwHAdWc/entityculling-fabric-1.6.2-mc1.20.1.jar"
+url = "https://cdn.modrinth.com/data/NNAgCjsB/versions/F3RXDl1W/entityculling-fabric-1.6.6-mc1.20.1.jar"
 hash-format = "sha1"
-hash = "8e4be2bb9703deddb3d3d212c812cdc1f9de072b"
+hash = "d6894508d74e5f01fb525b5b89d20ac4e54257b6"
 
 [update]
 [update.modrinth]
 mod-id = "NNAgCjsB"
-version = "BDwHAdWc"
+version = "F3RXDl1W"

--- a/mods/entitytexturefeatures.pw.toml
+++ b/mods/entitytexturefeatures.pw.toml
@@ -1,13 +1,13 @@
 name = "[ETF] Entity Texture Features"
-filename = "entity_texture_features_fabric_1.20.1-6.0.1.jar"
+filename = "entity_texture_features_fabric_1.20.1-6.1.1.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/BVzZfTc1/versions/jXc7eTKi/entity_texture_features_fabric_1.20.1-6.0.1.jar"
+url = "https://cdn.modrinth.com/data/BVzZfTc1/versions/Iqpdkpj4/entity_texture_features_fabric_1.20.1-6.1.1.jar"
 hash-format = "sha1"
-hash = "3c3e9c4b0a4ec11afa1cb3f98f614e77144901bd"
+hash = "e62ee98c326e64066edc91833291decd10c88950"
 
 [update]
 [update.modrinth]
 mod-id = "BVzZfTc1"
-version = "jXc7eTKi"
+version = "Iqpdkpj4"

--- a/mods/fabric-api.pw.toml
+++ b/mods/fabric-api.pw.toml
@@ -1,13 +1,13 @@
 name = "Fabric API"
-filename = "fabric-api-0.92.1+1.20.1.jar"
+filename = "fabric-api-0.92.2+1.20.1.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/P7dR8mSH/versions/ba99D9Qf/fabric-api-0.92.1%2B1.20.1.jar"
+url = "https://cdn.modrinth.com/data/P7dR8mSH/versions/P7uGFii0/fabric-api-0.92.2%2B1.20.1.jar"
 hash-format = "sha1"
-hash = "038ebcc315b5cf18c18f78f2447895dcb2ea9bac"
+hash = "625ee015ee426d9b677382a7bb661383d89c0807"
 
 [update]
 [update.modrinth]
 mod-id = "P7dR8mSH"
-version = "ba99D9Qf"
+version = "P7uGFii0"

--- a/mods/indium.pw.toml
+++ b/mods/indium.pw.toml
@@ -1,13 +1,13 @@
 name = "Indium"
-filename = "indium-1.0.30+mc1.20.4.jar"
+filename = "indium-1.0.32+mc1.20.1.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/Orvt0mRa/versions/Aouse6P7/indium-1.0.30%2Bmc1.20.4.jar"
+url = "https://cdn.modrinth.com/data/Orvt0mRa/versions/XPsoVC5n/indium-1.0.32%2Bmc1.20.1.jar"
 hash-format = "sha1"
-hash = "b24233f29c0ce4802c61ea8998e01e6e4580ae60"
+hash = "6689db86e97a6e112c36d276070fb537a1f3596e"
 
 [update]
 [update.modrinth]
 mod-id = "Orvt0mRa"
-version = "Aouse6P7"
+version = "XPsoVC5n"

--- a/mods/iris.pw.toml
+++ b/mods/iris.pw.toml
@@ -1,13 +1,13 @@
 name = "Iris Shaders"
-filename = "iris-1.7.0+mc1.20.1.jar"
+filename = "iris-1.7.1+mc1.20.1.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/YL57xq9U/versions/KHQ2Hnpt/iris-1.7.0%2Bmc1.20.1.jar"
+url = "https://cdn.modrinth.com/data/YL57xq9U/versions/G5dd9TM4/iris-1.7.1%2Bmc1.20.1.jar"
 hash-format = "sha1"
-hash = "28a02a9e2a4c881ed9e622aa0630276478383428"
+hash = "574992b5760f3bf2f9aa0b70984f19fb1952b748"
 
 [update]
 [update.modrinth]
 mod-id = "YL57xq9U"
-version = "KHQ2Hnpt"
+version = "G5dd9TM4"

--- a/mods/modernfix.pw.toml
+++ b/mods/modernfix.pw.toml
@@ -1,13 +1,13 @@
 name = "ModernFix"
-filename = "modernfix-fabric-5.17.0+mc1.20.1.jar"
+filename = "modernfix-fabric-5.18.1+mc1.20.1.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/nmDcB62a/versions/fh7tdNlS/modernfix-fabric-5.17.0%2Bmc1.20.1.jar"
+url = "https://cdn.modrinth.com/data/nmDcB62a/versions/CB2UOpt3/modernfix-fabric-5.18.1%2Bmc1.20.1.jar"
 hash-format = "sha1"
-hash = "69545d010ef782963d205484dabbfba9c139e42c"
+hash = "0639e7dd711b2e551f0a149035b91d9b83cf40dd"
 
 [update]
 [update.modrinth]
 mod-id = "nmDcB62a"
-version = "fh7tdNlS"
+version = "CB2UOpt3"

--- a/mods/sodium.pw.toml
+++ b/mods/sodium.pw.toml
@@ -1,13 +1,13 @@
 name = "Sodium"
-filename = "sodium-fabric-0.5.8+mc1.20.1.jar"
+filename = "sodium-fabric-0.5.10+mc1.20.1.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/AANobbMI/versions/mhZtY2lR/sodium-fabric-0.5.8%2Bmc1.20.1.jar"
+url = "https://cdn.modrinth.com/data/AANobbMI/versions/dEpHs0Hg/sodium-fabric-0.5.10%2Bmc1.20.1.jar"
 hash-format = "sha1"
-hash = "bdd6b8ac84b46ae56a3bbb761ce430c48e42e00d"
+hash = "0a47b4930e2340173e00470f8f9da51374aa765d"
 
 [update]
 [update.modrinth]
 mod-id = "AANobbMI"
-version = "mhZtY2lR"
+version = "dEpHs0Hg"

--- a/mods/yacl.pw.toml
+++ b/mods/yacl.pw.toml
@@ -1,13 +1,13 @@
 name = "YetAnotherConfigLib"
-filename = "YetAnotherConfigLib-3.4.2+1.20.1-fabric.jar"
+filename = "YetAnotherConfigLib-3.5.0+1.20.1-fabric.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/1eAoo2KR/versions/TD5Fv92S/YetAnotherConfigLib-3.4.2%2B1.20.1-fabric.jar"
+url = "https://cdn.modrinth.com/data/1eAoo2KR/versions/gQuF6HNa/YetAnotherConfigLib-3.5.0%2B1.20.1-fabric.jar"
 hash-format = "sha1"
-hash = "4ae011ae4a1c9c1f012b7c6f22d2a8f57791d9df"
+hash = "48005e145f5423ff9446ac6fe3d1cb122f977a00"
 
 [update]
 [update.modrinth]
 mod-id = "1eAoo2KR"
-version = "TD5Fv92S"
+version = "gQuF6HNa"

--- a/pack.toml
+++ b/pack.toml
@@ -1,12 +1,12 @@
 name = "Valorium"
 author = "Riser876 / GMalvestiti"
-version = "0.16.2"
+version = "0.17.0"
 pack-format = "packwiz:1.1.0"
 
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "f1ef4cd5a1945c10e3312f4c20c6f1f1559191ac7aa05dda2f59d5d93df69a06"
+hash = "f5a999ca1880064e34b4a4a37f67248498b64a384e25d91187c972394aaa2100"
 
 [versions]
 fabric = "0.15.11"


### PR DESCRIPTION
- **Adicionado**:
  - Configurações para Item Highlighter v1.1.9

- **Modificado**:
  - Balm v7.2.2 para v7.3.4
  - Entity Culling v1.6.2 para v1.6.6
  - [ETF] Entity Texture Features v6.0.1 para v6.1.1
  - Fabric API v0.92.1 para v0.92.2
  - Indium v1.0.30 para v1.0.32
  - Iris Shaders v1.7.0 para v1.7.1
  - ModernFix v5.17.0 para v5.18.1
  - Sodium v0.5.8 para v0.5.10
  - YetAnotherConfigLib v3.4.2 para v3.5.0